### PR TITLE
Add MinValueValidator to enforce values greater than 5

### DIFF
--- a/src/tsa_products/migrations/0002_add_min_value_validator_to_category_height_width.py
+++ b/src/tsa_products/migrations/0002_add_min_value_validator_to_category_height_width.py
@@ -1,0 +1,22 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("tsa_products", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="category",
+            name="height",
+            field=models.FloatField(default=5.0, validators=[django.core.validators.MinValueValidator(5)]),
+        ),
+        migrations.AlterField(
+            model_name="category",
+            name="width",
+            field=models.FloatField(default=5.0, validators=[django.core.validators.MinValueValidator(5)]),
+        ),
+    ]

--- a/src/tsa_products/models.py
+++ b/src/tsa_products/models.py
@@ -1,4 +1,4 @@
-from django.core.validators import RegexValidator
+from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
 
 COLOR_VALIDATOR = RegexValidator(r"^#(?:[0-9a-fA-F]{3}){1,2}$", "only valid hex color code is accepted")
@@ -12,8 +12,8 @@ class Category(models.Model):
     base_price = models.FloatField(default=0.0)
     # -1 means any positive amount
     max_amount_of_lettering_items = models.IntegerField(default=-1)
-    height = models.FloatField(default=0.0)
-    width = models.FloatField(default=0.0)
+    height = models.FloatField(default=5.0, validators=[MinValueValidator(5)])
+    width = models.FloatField(default=5.0, validators=[MinValueValidator(5)])
 
     class Meta:
         verbose_name_plural = "categories"

--- a/src/tsa_products/tests/test_category.py
+++ b/src/tsa_products/tests/test_category.py
@@ -11,8 +11,8 @@ class CategoryTestCase(TestCase):
         self.test_image = "test-path"
         self.test_base_price = 0.0
         self.test_max_amount_of_lettering_items = -1
-        self.test_height = 0.0
-        self.test_width = 0.0
+        self.test_height = 5.0
+        self.test_width = 5.0
 
     def setUp(self):
         # Deletes all Category objects from the database to ensure a clean state before each test.
@@ -45,4 +45,28 @@ class CategoryTestCase(TestCase):
             category = Category(title=self.test_title)
             category.full_clean()
             category.save()
+        self.assertEqual(Category.objects.count(), 0)
+
+    def test_failure_category_creation_with_height_below_minimum(self):
+        """Test that a height value below 5 raises a ValidationError."""
+        with self.assertRaises(ValidationError):
+            category = Category(
+                title=self.test_title,
+                image=self.test_image,
+                height=4.9,
+                width=self.test_width,
+            )
+            category.full_clean()
+        self.assertEqual(Category.objects.count(), 0)
+
+    def test_failure_category_creation_with_width_below_minimum(self):
+        """Test that a width value below 5 raises a ValidationError."""
+        with self.assertRaises(ValidationError):
+            category = Category(
+                title=self.test_title,
+                image=self.test_image,
+                height=self.test_height,
+                width=0.0,
+            )
+            category.full_clean()
         self.assertEqual(Category.objects.count(), 0)


### PR DESCRIPTION
This pull request updates the `Category` model to enforce a minimum value of 5 for both the `height` and `width` fields, ensures these defaults are set throughout the codebase, and adds tests to verify these constraints.

**Model validation and defaults:**

* Updated the `Category` model so that `height` and `width` default to 5.0 and now include a `MinValueValidator(5)` to enforce a minimum value of 5.
* Added a Django migration to apply the new default values and validators to the database schema.

**Test updates:**

* Updated test setup to use the new default values for `height` and `width`.
* Added tests to ensure that creating a `Category` with `height` or `width` below 5 raises a `ValidationError`.

**Imports:**

* Updated imports in `models.py` to include `MinValueValidator`.